### PR TITLE
删除canvasDiv，canvas下拉适应

### DIFF
--- a/canvas-particle.js
+++ b/canvas-particle.js
@@ -10,7 +10,6 @@ var CanvasParticle = (function(){
 		canvasConfig = canvasConfig || {};
 		var html = getElementByTag("html")[0];
 		var body = getElementByTag("body")[0];
-		var canvasDiv = getELementById("canvas-particle");
 		var canvasObj = document.createElement("canvas");
 
 		var canvas = {
@@ -43,7 +42,7 @@ var CanvasParticle = (function(){
 		// body.replaceChild(canvas.element, canvasDiv);
 		body.appendChild(canvas.element);
 
-		canvas.element.style = "position: absolute; top: 0; left: 0; z-index: -1;";
+		canvas.element.style = "position: fixed; top: 0; left: 0; z-index: -1;";
 		canvasSize(canvas.element);
 		window.onresize = function(){
 			canvasSize(canvas.element);


### PR DESCRIPTION
您好，在用CanvasParticles粒子背景效果的时候发现了一个问题，就是当我的网页长度大于一个屏幕的时候，需要浏览器右侧的下拉框进行浏览网页，这时候粒子背景并不能够进行resize，也就是说网页的下半部分并没有覆盖粒子背景。
然后就浏览了一下源码，并修改了canvas的position属性为fixed，让粒子背景的位置相对于屏幕固定，不知道有没有更好的解决办法。
另外发现canvasDiv这个变量后面并没有使用，可以考虑删除。
[这是我博客添加粒子背景，修改之后的效果](https://v4if.github.io/)